### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -1,4 +1,6 @@
 name: Run PR Tests
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/djoamersfoort/aanmelden/security/code-scanning/3](https://github.com/djoamersfoort/aanmelden/security/code-scanning/3)

To fix the issue, add a `permissions` block at the root level of the workflow file. This block should specify the minimal permissions required for the workflow to function. Based on the provided workflow, the only required permission is `contents: read`, which allows the workflow to access the repository's contents for tasks like checking out the code and installing dependencies. No write permissions are necessary.

The `permissions` block should be added immediately after the `name` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
